### PR TITLE
initialize patch to test DF process fix

### DIFF
--- a/gap_filling/data_handler.py
+++ b/gap_filling/data_handler.py
@@ -72,7 +72,7 @@ class DataHandler:
                 curs.execute(
                     "SELECT original_inventory_sector, reporting_entity, iso3_country, "
                     "gas, emissions_quantity, emissions_quantity_units, start_time, temporal_granularity "
-                    "FROM country_emissions_data_fusion WHERE reporting_entity = %s AND start_time >= %s "
+                    "FROM country_emissions_monthly WHERE reporting_entity = %s AND start_time >= %s "
                     "AND gas != 'co2e_100yr' AND gas != 'co2e_20yr'",
                     (source, start_date),
                 )
@@ -90,7 +90,7 @@ class DataHandler:
                     curs.execute(
                         "SELECT original_inventory_sector, reporting_entity, iso3_country, "
                         "gas, emissions_quantity, emissions_quantity_units, start_time, temporal_granularity "
-                        "FROM country_emissions_data_fusion WHERE reporting_entity = %s AND start_time >= %s "
+                        "FROM country_emissions_monthly WHERE reporting_entity = %s AND start_time >= %s "
                         "AND gas != 'co2e_100yr' AND gas != 'co2e_20yr'",
                         (source, start_date),
                     )

--- a/gap_filling/fill_gaps.py
+++ b/gap_filling/fill_gaps.py
@@ -56,9 +56,12 @@ def fill_all_sector_gaps(input_df, ge=None, output_intermediate_data=False):
     df_merge[COMP_YEARS] = df_merge[COMP_YEARS].multiply(df_merge["values"], axis=0)
 
     # For each (Country, Gas, and sector to be gap filled) group, sum up all the corresponding values per year
-    sectors_gap_filled = df_merge.groupby(
-        ["ID", "Gas", "to_be_gap_filled", "Unit"], as_index=False
-    )[COMP_YEARS].sum()
+    # sectors_gap_filled = df_merge.groupby(
+    #     ["ID", "Gas", "to_be_gap_filled", "Unit"], as_index=False
+    # )[COMP_YEARS].sum()
+
+    sectors_gap_filled = df_merge.groupby(["ID", "Gas", "to_be_gap_filled", "Unit"], as_index=False)\
+        [COMP_YEARS].agg(lambda x: np.nan if x.isna().any() else x.sum())
 
     # Add in removed columns and rename others
     sectors_gap_filled.rename(columns={"to_be_gap_filled": "Sector"}, inplace=True)
@@ -70,7 +73,6 @@ def fill_all_sector_gaps(input_df, ge=None, output_intermediate_data=False):
 
     if output_intermediate_data:
         sectors_gap_filled.to_csv('20231020_gap_fill_before_clean.csv')
-    # sectors_gap_filled[COL_ORDER + "Created"].to_csv('/Users/leegans/Downloads/watttime/gapupdated.csv')
     new_ct_entries = data_cleaning(sectors_gap_filled)
 
     return new_ct_entries[COL_ORDER]


### PR DESCRIPTION
This should not be merged.

This accompanies the PR in the DF code: https://github.com/WattTime/climate-trace-data-fusion/pull/379

The purpose is to prevent the gap equations from resulting in "0" where data from the inventories are missing (i.e. where forward filling would need to happen). This allows the DF pipeline to fill in using its default processes. This update is needed locally in order to run the tests in the PR above.